### PR TITLE
Fix RoutineList Grid definitions

### DIFF
--- a/Planner/Views/RoutineListPage.xaml
+++ b/Planner/Views/RoutineListPage.xaml
@@ -7,7 +7,7 @@
         <CollectionView ItemsSource="{Binding Routines}">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
-                    <Grid ColumnDefinitions="* Auto" Padding="0,5">
+                    <Grid ColumnDefinitions="*,Auto" Padding="0,5">
                         <Label Text="{Binding Name}" VerticalOptions="Center" />
                         <Button Grid.Column="1" Text="Toggle" Command="{Binding BindingContext.ToggleRoutineCommand, Source={x:Reference Page}}" CommandParameter="{Binding .}" />
                     </Grid>


### PR DESCRIPTION
## Summary
- fix the `RoutineListPage` grid ColumnDefinitions syntax

## Testing
- `dotnet build Planner.sln -v minimal` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68567221622c833189a6483f370e9b99