### PR TITLE
Implement daily routine completion tracking

### DIFF
--- a/Planner/Models/DataStore.cs
+++ b/Planner/Models/DataStore.cs
@@ -6,5 +6,8 @@ namespace Planner.Models
     {
         public List<Goal> Goals { get; set; } = new();
         public List<Routine> Routines { get; set; } = new();
+
+        // Tracks routine completion status by date
+        public Dictionary<string, List<Routine>> RoutineProgress { get; set; } = new();
     }
 }

--- a/Planner/Models/Routine.cs
+++ b/Planner/Models/Routine.cs
@@ -9,5 +9,11 @@ namespace Planner.Models
         public string RepeatInterval { get; set; } = "Daily"; // Daily/Weekly/etc.
         public DateTime? LastCompletedDate { get; set; }
         public int StreakCount { get; set; }
+
+        // Date this routine entry applies to
+        public DateTime Date { get; set; } = DateTime.Today;
+
+        // Indicates if the routine has been completed for the given date
+        public bool IsCompleted { get; set; }
     }
 }

--- a/Planner/ViewModels/RoutineListViewModel.cs
+++ b/Planner/ViewModels/RoutineListViewModel.cs
@@ -20,24 +20,14 @@ namespace Planner.ViewModels
 
         public async Task LoadAsync()
         {
-            Routines = await _dataService.GetRoutinesAsync();
+            Routines = await _dataService.GetTodayRoutinesAsync();
         }
 
         [RelayCommand]
         private async Task ToggleRoutine(Routine routine)
         {
-            if (routine.LastCompletedDate?.Date == DateTime.Today)
-            {
-                routine.LastCompletedDate = null;
-                routine.StreakCount = Math.Max(0, routine.StreakCount - 1);
-            }
-            else
-            {
-                routine.LastCompletedDate = DateTime.Today;
-                routine.StreakCount++;
-            }
-
-            await _dataService.UpdateRoutineAsync(routine);
+            routine.IsCompleted = !routine.IsCompleted;
+            await _dataService.UpdateTodayRoutineAsync(routine);
             await LoadAsync();
         }
 

--- a/Planner/Views/RoutineListPage.xaml
+++ b/Planner/Views/RoutineListPage.xaml
@@ -7,9 +7,9 @@
         <CollectionView ItemsSource="{Binding Routines}">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
-                    <Grid ColumnDefinitions="*,Auto" Padding="0,5">
-                        <Label Text="{Binding Name}" VerticalOptions="Center" />
-                        <Button Grid.Column="1" Text="Toggle" Command="{Binding BindingContext.ToggleRoutineCommand, Source={x:Reference Page}}" CommandParameter="{Binding .}" />
+                    <Grid ColumnDefinitions="Auto,*" Padding="0,5">
+                        <CheckBox IsChecked="{Binding IsCompleted}" CheckedChanged="OnRoutineChecked" />
+                        <Label Grid.Column="1" Text="{Binding Name}" VerticalOptions="Center" />
                     </Grid>
                 </DataTemplate>
             </CollectionView.ItemTemplate>

--- a/Planner/Views/RoutineListPage.xaml.cs
+++ b/Planner/Views/RoutineListPage.xaml.cs
@@ -18,5 +18,13 @@ namespace Planner.Views
         {
             await _vm.LoadAsync();
         }
+
+        private void OnRoutineChecked(object? sender, CheckedChangedEventArgs e)
+        {
+            if (sender is CheckBox cb && cb.BindingContext is Planner.Models.Routine routine)
+            {
+                _vm.ToggleRoutineCommand.Execute(routine);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- track completion status for routines per day
- store daily routine progress in `DataStore`
- add loading of today's routines and toggling completion
- show routines with checkboxes and save when toggled

## Testing
- `dotnet build Planner/Planner.csproj -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685675d7770c833195dd7a2c5e7fdbc8