### PR TITLE
Add monthly calendar page with routine tracking

### DIFF
--- a/Planner/AppShell.xaml
+++ b/Planner/AppShell.xaml
@@ -19,4 +19,8 @@
         Title="Goals"
         ContentTemplate="{DataTemplate views:GoalListPage}"
         Route="GoalListPage" />
+    <ShellContent
+        Title="Calendar"
+        ContentTemplate="{DataTemplate views:CalendarPage}"
+        Route="CalendarPage" />
 </Shell>

--- a/Planner/Converters/SelectedDateBgConverter.cs
+++ b/Planner/Converters/SelectedDateBgConverter.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Globalization;
+using Microsoft.Maui.Controls;
+using Planner.ViewModels;
+
+namespace Planner.Converters
+{
+    public class SelectedDateBgConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is DateTime date && parameter is Element element && element.BindingContext is CalendarViewModel vm)
+            {
+                return vm.SelectedDate.Date == date.Date ? Colors.LightBlue : Colors.Transparent;
+            }
+            return Colors.Transparent;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Planner/MauiProgram.cs
+++ b/Planner/MauiProgram.cs
@@ -23,10 +23,13 @@ namespace Planner
 #endif
 
             builder.Services.AddSingleton<DataService>();
+            builder.Services.AddSingleton<RoutineService>();
             builder.Services.AddTransient<GoalListViewModel>();
             builder.Services.AddTransient<RoutineListViewModel>();
+            builder.Services.AddTransient<CalendarViewModel>();
             builder.Services.AddTransient<GoalListPage>();
             builder.Services.AddTransient<RoutineListPage>();
+            builder.Services.AddTransient<CalendarPage>();
 
             return builder.Build();
         }

--- a/Planner/Services/RoutineService.cs
+++ b/Planner/Services/RoutineService.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Maui.Storage;
+using Planner.Models;
+
+namespace Planner.Services
+{
+    public class RoutineService
+    {
+        private readonly string _filePath;
+        private Dictionary<string, List<Routine>> _routinesByDate = new();
+
+        public RoutineService()
+        {
+            _filePath = Path.Combine(FileSystem.AppDataDirectory, "routines.json");
+        }
+
+        private async Task LoadAsync()
+        {
+            if (File.Exists(_filePath))
+            {
+                var json = await File.ReadAllTextAsync(_filePath);
+                _routinesByDate = JsonSerializer.Deserialize<Dictionary<string, List<Routine>>>(json) ?? new();
+            }
+        }
+
+        private async Task SaveAsync()
+        {
+            var json = JsonSerializer.Serialize(_routinesByDate, new JsonSerializerOptions { WriteIndented = true });
+            var directory = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+                Directory.CreateDirectory(directory!);
+            await File.WriteAllTextAsync(_filePath, json);
+        }
+
+        public async Task<List<Routine>> GetRoutinesByDate(DateTime date)
+        {
+            await LoadAsync();
+            var key = date.ToString("yyyy-MM-dd");
+            if (_routinesByDate.TryGetValue(key, out var routines))
+            {
+                return routines;
+            }
+            return new List<Routine>();
+        }
+
+        public async Task SaveRoutineForDate(Routine routine)
+        {
+            await LoadAsync();
+            var key = routine.Date.ToString("yyyy-MM-dd");
+            if (!_routinesByDate.TryGetValue(key, out var routines))
+            {
+                routines = new List<Routine>();
+                _routinesByDate[key] = routines;
+            }
+            var index = routines.FindIndex(r => r.Id == routine.Id);
+            if (index >= 0)
+                routines[index] = routine;
+            else
+                routines.Add(routine);
+
+            await SaveAsync();
+        }
+    }
+}

--- a/Planner/ViewModels/CalendarViewModel.cs
+++ b/Planner/ViewModels/CalendarViewModel.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Planner.Models;
+using Planner.Services;
+
+namespace Planner.ViewModels
+{
+    public partial class CalendarViewModel : ObservableObject
+    {
+        private readonly RoutineService _routineService;
+
+        [ObservableProperty]
+        private DateTime _selectedDate = DateTime.Today;
+
+        [ObservableProperty]
+        private List<DateTime> _days = new();
+
+        [ObservableProperty]
+        private List<Routine> _routines = new();
+
+        [ObservableProperty]
+        private string _monthTitle = string.Empty;
+
+        public CalendarViewModel(RoutineService routineService)
+        {
+            _routineService = routineService;
+            GenerateDays();
+        }
+
+        public async Task LoadAsync()
+        {
+            await LoadRoutinesAsync();
+        }
+
+        partial void OnSelectedDateChanged(DateTime value)
+        {
+            GenerateDays();
+            _ = LoadRoutinesAsync();
+        }
+
+        private void GenerateDays()
+        {
+            var firstOfMonth = new DateTime(SelectedDate.Year, SelectedDate.Month, 1);
+            var firstDay = firstOfMonth.AddDays(-(int)firstOfMonth.DayOfWeek);
+            var list = new List<DateTime>();
+            for (int i = 0; i < 35; i++)
+            {
+                list.Add(firstDay.AddDays(i));
+            }
+            Days = list;
+            MonthTitle = SelectedDate.ToString("MMMM yyyy");
+        }
+
+        private async Task LoadRoutinesAsync()
+        {
+            Routines = await _routineService.GetRoutinesByDate(SelectedDate);
+        }
+
+        [RelayCommand]
+        private void SelectDate(DateTime date)
+        {
+            SelectedDate = date;
+        }
+
+        [RelayCommand]
+        private async Task ToggleRoutine(Routine routine)
+        {
+            routine.IsCompleted = !routine.IsCompleted;
+            routine.Date = SelectedDate;
+            await _routineService.SaveRoutineForDate(routine);
+            await LoadRoutinesAsync();
+        }
+
+        [RelayCommand]
+        private async Task AddRoutine()
+        {
+            var routine = new Routine { Name = "New Routine", Date = SelectedDate };
+            await _routineService.SaveRoutineForDate(routine);
+            await LoadRoutinesAsync();
+        }
+    }
+}

--- a/Planner/Views/CalendarPage.xaml
+++ b/Planner/Views/CalendarPage.xaml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:converters="clr-namespace:Planner.Converters"
+             x:Class="Planner.Views.CalendarPage" x:Name="Page">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <converters:SelectedDateBgConverter x:Key="SelectedDateBgConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <StackLayout Padding="20" Spacing="10">
+        <Label Text="{Binding MonthTitle}" HorizontalOptions="Center" FontAttributes="Bold" />
+        <CollectionView ItemsSource="{Binding Days}" SelectionMode="None">
+            <CollectionView.ItemsLayout>
+                <GridItemsLayout Orientation="Vertical" Span="7" />
+            </CollectionView.ItemsLayout>
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Border Padding="5" BackgroundColor="{Binding Converter={StaticResource SelectedDateBgConverter}, ConverterParameter={x:Reference Page}}">
+                        <Label Text="{Binding ., StringFormat='{0:dd}'}" HorizontalOptions="Center" VerticalOptions="Center">
+                            <Label.GestureRecognizers>
+                                <TapGestureRecognizer Command="{Binding Source={x:Reference Page}, Path=BindingContext.SelectDateCommand}" CommandParameter="{Binding .}" />
+                            </Label.GestureRecognizers>
+                        </Label>
+                    </Border>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+        <Button Text="+" Command="{Binding AddRoutineCommand}" HorizontalOptions="End" />
+        <Label Text="No routines scheduled" IsVisible="False">
+            <Label.Triggers>
+                <DataTrigger TargetType="Label" Binding="{Binding Routines.Count}" Value="0">
+                    <Setter Property="IsVisible" Value="True" />
+                </DataTrigger>
+            </Label.Triggers>
+        </Label>
+        <CollectionView ItemsSource="{Binding Routines}">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid ColumnDefinitions="Auto,*" Padding="0,5">
+                        <CheckBox IsChecked="{Binding IsCompleted}" CheckedChanged="OnRoutineChecked" />
+                        <Label Grid.Column="1" Text="{Binding Name}" VerticalOptions="Center" />
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </StackLayout>
+</ContentPage>

--- a/Planner/Views/CalendarPage.xaml.cs
+++ b/Planner/Views/CalendarPage.xaml.cs
@@ -1,0 +1,30 @@
+using System;
+using Planner.ViewModels;
+
+namespace Planner.Views
+{
+    public partial class CalendarPage : ContentPage
+    {
+        private readonly CalendarViewModel _vm;
+        public CalendarPage(CalendarViewModel vm)
+        {
+            InitializeComponent();
+            _vm = vm;
+            BindingContext = _vm;
+            Loaded += CalendarPage_Loaded;
+        }
+
+        private async void CalendarPage_Loaded(object? sender, EventArgs e)
+        {
+            await _vm.LoadAsync();
+        }
+
+        private void OnRoutineChecked(object? sender, CheckedChangedEventArgs e)
+        {
+            if (sender is CheckBox cb && cb.BindingContext is Planner.Models.Routine routine)
+            {
+                _vm.ToggleRoutineCommand.Execute(routine);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `RoutineService` with date-specific storage
- show monthly routines in new `CalendarPage`
- connect `CalendarViewModel`
- add selected date highlight converter
- register services and page in `MauiProgram`
- add Calendar tab to `AppShell`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68567c3bf9a483318870f721ca5c671a