### PR TITLE
Fix Border CornerRadius usage in CalendarPage

### DIFF
--- a/Planner/Views/CalendarPage.xaml
+++ b/Planner/Views/CalendarPage.xaml
@@ -20,7 +20,10 @@
                     <CollectionView.ItemTemplate>
                         <DataTemplate>
                             <Grid Padding="3">
-                                <Border BackgroundColor="{Binding Converter={StaticResource SelectedDateBgConverter}, ConverterParameter={x:Reference Page}}" Stroke="LightGray" CornerRadius="6">
+                                <Border BackgroundColor="{Binding Converter={StaticResource SelectedDateBgConverter}, ConverterParameter={x:Reference Page}}" Stroke="LightGray" >
+                                    <Border.StrokeShape>
+                                        <RoundRectangle CornerRadius="6" />
+                                    </Border.StrokeShape>
                                     <Grid>
                                         <Label Text="{Binding ., StringFormat='{0:dd}'}" HorizontalOptions="Center" VerticalOptions="Center">
                                             <Label.GestureRecognizers>


### PR DESCRIPTION
## Summary
- fix XAML syntax for Border CornerRadius using StrokeShape

## Testing
- `dotnet build Planner/Planner.csproj -c Release -p:TargetFrameworks=net9.0-android` *(fails: Android SDK directory could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_685696b74bb88331a8f2792f6bc69101