### PR TITLE
Add weekly stats page

### DIFF
--- a/Planner/AppShell.xaml
+++ b/Planner/AppShell.xaml
@@ -18,4 +18,8 @@
         Title="Goals"
         ContentTemplate="{DataTemplate views:GoalListPage}"
         Route="GoalListPage" />
+    <ShellContent
+        Title="Stats"
+        ContentTemplate="{DataTemplate views:StatsPage}"
+        Route="StatsPage" />
 </Shell>

--- a/Planner/AppShell.xaml.cs
+++ b/Planner/AppShell.xaml.cs
@@ -8,6 +8,7 @@ namespace Planner
             Routing.RegisterRoute(nameof(Views.RoutineListPage), typeof(Views.RoutineListPage));
             Routing.RegisterRoute(nameof(Views.GoalListPage), typeof(Views.GoalListPage));
             Routing.RegisterRoute(nameof(Views.CalendarPage), typeof(Views.CalendarPage));
+            Routing.RegisterRoute(nameof(Views.StatsPage), typeof(Views.StatsPage));
         }
     }
 }

--- a/Planner/MauiProgram.cs
+++ b/Planner/MauiProgram.cs
@@ -27,9 +27,11 @@ namespace Planner
             builder.Services.AddTransient<GoalListViewModel>();
             builder.Services.AddTransient<RoutineListViewModel>();
             builder.Services.AddTransient<CalendarViewModel>();
+            builder.Services.AddTransient<StatsViewModel>();
             builder.Services.AddTransient<GoalListPage>();
             builder.Services.AddTransient<RoutineListPage>();
             builder.Services.AddTransient<CalendarPage>();
+            builder.Services.AddTransient<StatsPage>();
 
             return builder.Build();
         }

--- a/Planner/Services/RoutineService.cs
+++ b/Planner/Services/RoutineService.cs
@@ -95,5 +95,44 @@ namespace Planner.Services
             }
             return result;
         }
+
+        public async Task<Dictionary<DateTime, List<Routine>>> GetRoutinesForRange(DateTime start, DateTime end)
+        {
+            await LoadAsync();
+            var result = new Dictionary<DateTime, List<Routine>>();
+            foreach (var kvp in _routinesByDate)
+            {
+                if (DateTime.TryParse(kvp.Key, out var date))
+                {
+                    if (date >= start && date <= end)
+                        result[date] = new List<Routine>(kvp.Value);
+                }
+            }
+            return result;
+        }
+
+        public async Task<int> GetTotalCompletedInRange(DateTime start, DateTime end)
+        {
+            var routines = await GetRoutinesForRange(start, end);
+            return routines.Values.Sum(list => list.Count(r => r.IsCompleted));
+        }
+
+        public async Task<int> GetTotalPlannedInRange(DateTime start, DateTime end)
+        {
+            var routines = await GetRoutinesForRange(start, end);
+            return routines.Values.Sum(list => list.Count);
+        }
+
+        public async Task<int> GetFullCompletionDaysInRange(DateTime start, DateTime end)
+        {
+            var routines = await GetRoutinesForRange(start, end);
+            int count = 0;
+            foreach (var list in routines.Values)
+            {
+                if (list.Count > 0 && list.All(r => r.IsCompleted))
+                    count++;
+            }
+            return count;
+        }
     }
 }

--- a/Planner/ViewModels/StatsViewModel.cs
+++ b/Planner/ViewModels/StatsViewModel.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Planner.Services;
+
+namespace Planner.ViewModels
+{
+    public partial class StatsViewModel : ObservableObject
+    {
+        private readonly RoutineService _routineService;
+
+        [ObservableProperty]
+        private string _weekRangeTitle = string.Empty;
+
+        [ObservableProperty]
+        private int _routinesCompleted;
+
+        [ObservableProperty]
+        private int _fullCompletionDays;
+
+        [ObservableProperty]
+        private double _completionPercentage;
+
+        public StatsViewModel(RoutineService routineService)
+        {
+            _routineService = routineService;
+        }
+
+        public async Task LoadAsync()
+        {
+            var today = DateTime.Today;
+            var start = today.AddDays(-(int)today.DayOfWeek);
+            var end = start.AddDays(6);
+
+            WeekRangeTitle = $"Week of {start:MMMM d} – {end:MMMM d}";
+
+            var completed = await _routineService.GetTotalCompletedInRange(start, end);
+            var planned = await _routineService.GetTotalPlannedInRange(start, end);
+            var fullDays = await _routineService.GetFullCompletionDaysInRange(start, end);
+
+            RoutinesCompleted = completed;
+            FullCompletionDays = fullDays;
+            CompletionPercentage = planned == 0 ? 0 : (double)completed / planned * 100.0;
+        }
+    }
+}

--- a/Planner/Views/StatsPage.xaml
+++ b/Planner/Views/StatsPage.xaml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Planner.Views.StatsPage"
+             x:Name="Page">
+    <Grid>
+        <ScrollView>
+            <StackLayout Padding="20" Spacing="20">
+                <Frame HasShadow="True" CornerRadius="12" Padding="20"
+                       BackgroundColor="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Gray900}}">
+                    <StackLayout Spacing="10">
+                        <Label Text="{Binding WeekRangeTitle}" HorizontalOptions="Center" FontAttributes="Bold" />
+                        <Label Text="{Binding RoutinesCompleted, StringFormat='✅  {0} routines completed'}" HorizontalOptions="Center" />
+                        <Label Text="{Binding FullCompletionDays, StringFormat='🔁  {0} days fully completed'}" HorizontalOptions="Center" />
+                        <Label Text="{Binding CompletionPercentage, StringFormat='📈  {0:F0}% completion rate'}" HorizontalOptions="Center" />
+                    </StackLayout>
+                </Frame>
+            </StackLayout>
+        </ScrollView>
+    </Grid>
+</ContentPage>

--- a/Planner/Views/StatsPage.xaml.cs
+++ b/Planner/Views/StatsPage.xaml.cs
@@ -1,0 +1,23 @@
+using System;
+using Planner.ViewModels;
+
+namespace Planner.Views
+{
+    public partial class StatsPage : ContentPage
+    {
+        private readonly StatsViewModel _vm;
+
+        public StatsPage(StatsViewModel vm)
+        {
+            InitializeComponent();
+            _vm = vm;
+            BindingContext = _vm;
+            Loaded += StatsPage_Loaded;
+        }
+
+        private async void StatsPage_Loaded(object? sender, EventArgs e)
+        {
+            await _vm.LoadAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add StatsPage with a StatsViewModel
- extend RoutineService with range helpers
- register and route StatsPage
- wire new view into DI

## Testing
- `dotnet build Planner.sln -c Release` *(fails: workloads missing)*

------
https://chatgpt.com/codex/tasks/task_e_68569aa2b6dc83319353757fa538ed16