### PR TITLE
Add routine reminder notifications

### DIFF
--- a/Planner/App.xaml.cs
+++ b/Planner/App.xaml.cs
@@ -1,10 +1,16 @@
-﻿namespace Planner
+﻿using Planner.Services;
+
+namespace Planner
 {
     public partial class App : Application
     {
-        public App()
+        private readonly ReminderService _reminderService;
+
+        public App(ReminderService reminderService)
         {
             InitializeComponent();
+            _reminderService = reminderService;
+            _ = _reminderService.RescheduleTodayRemindersAsync();
         }
 
         protected override Window CreateWindow(IActivationState? activationState)

--- a/Planner/MauiProgram.cs
+++ b/Planner/MauiProgram.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Planner.Services;
+using Plugin.LocalNotification;
 using Planner.ViewModels;
 using Planner.Views;
 
@@ -12,6 +13,7 @@ namespace Planner
             var builder = MauiApp.CreateBuilder();
             builder
                 .UseMauiApp<App>()
+                .UseLocalNotification()
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
@@ -24,6 +26,7 @@ namespace Planner
 
             builder.Services.AddSingleton<DataService>();
             builder.Services.AddSingleton<RoutineService>();
+            builder.Services.AddSingleton<ReminderService>();
             builder.Services.AddTransient<GoalListViewModel>();
             builder.Services.AddTransient<RoutineListViewModel>();
             builder.Services.AddTransient<RoutineTemplateViewModel>();

--- a/Planner/Models/Routine.cs
+++ b/Planner/Models/Routine.cs
@@ -22,5 +22,11 @@ namespace Planner.Models
 
         // Indicates if the routine has been completed for the given date
         public bool IsCompleted { get; set; }
+
+        // Time of day the reminder should fire. Null if no reminder
+        public TimeSpan? ReminderTime { get; set; }
+
+        // Whether a reminder is enabled for this routine
+        public bool IsReminderEnabled { get; set; }
     }
 }

--- a/Planner/Planner.csproj
+++ b/Planner/Planner.csproj
@@ -63,6 +63,7 @@
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
                 <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
-	</ItemGroup>
+                <PackageReference Include="Plugin.LocalNotification" Version="16.0.0" />
+        </ItemGroup>
 
 </Project>

--- a/Planner/Platforms/Android/AndroidManifest.xml
+++ b/Planner/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission android:name="android.permission.INTERNET" />
+        <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+        <uses-permission android:name="android.permission.INTERNET" />
+        <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 </manifest>

--- a/Planner/Services/ReminderService.cs
+++ b/Planner/Services/ReminderService.cs
@@ -1,0 +1,56 @@
+using System;
+using Plugin.LocalNotification;
+using Planner.Models;
+
+namespace Planner.Services
+{
+    public class ReminderService
+    {
+        private readonly RoutineService _routineService;
+
+        public ReminderService(RoutineService routineService)
+        {
+            _routineService = routineService;
+        }
+
+        private int GetNotificationId(Guid id) => Math.Abs(id.GetHashCode());
+
+        public async Task ScheduleReminderAsync(Routine routine)
+        {
+            if (!routine.IsReminderEnabled || !routine.ReminderTime.HasValue || routine.IsCompleted)
+                return;
+
+            var notifyTime = routine.Date.Date + routine.ReminderTime.Value;
+            if (notifyTime <= DateTime.Now)
+                return;
+
+            var request = new NotificationRequest
+            {
+                NotificationId = GetNotificationId(routine.Id),
+                Title = "Routine Reminder",
+                Description = routine.Name,
+                Schedule = new NotificationRequestSchedule
+                {
+                    NotifyTime = notifyTime,
+                    RepeatType = NotificationRepeat.No
+                }
+            };
+            NotificationCenter.Current.Show(request);
+        }
+
+        public void CancelReminder(Guid id)
+        {
+            NotificationCenter.Current.Cancel(GetNotificationId(id));
+        }
+
+        public async Task RescheduleTodayRemindersAsync()
+        {
+            NotificationCenter.Current.CancelAll();
+            var routines = await _routineService.GetRoutinesByDate(DateTime.Today);
+            foreach (var r in routines)
+            {
+                await ScheduleReminderAsync(r);
+            }
+        }
+    }
+}

--- a/Planner/Services/RoutineService.cs
+++ b/Planner/Services/RoutineService.cs
@@ -215,7 +215,9 @@ namespace Planner.Services
                             Name = template.Name,
                             RepeatInterval = template.RepeatInterval,
                             Date = date,
-                            IsCompleted = false
+                            IsCompleted = false,
+                            IsReminderEnabled = template.IsReminderEnabled,
+                            ReminderTime = template.ReminderTime
                         };
                         routines.Add(r);
                     }

--- a/Planner/Views/CalendarPage.xaml
+++ b/Planner/Views/CalendarPage.xaml
@@ -63,7 +63,7 @@
                                 <Frame Padding="10" Margin="0,5" HasShadow="True" BackgroundColor="White" CornerRadius="8">
                                     <Grid ColumnDefinitions="Auto,*" VerticalOptions="Center">
                                         <CheckBox IsChecked="{Binding IsCompleted}" CheckedChanged="OnRoutineChecked" VerticalOptions="Center" />
-                                        <Label Grid.Column="1" Text="{Binding Name}" VerticalOptions="Center">
+                                        <Label Grid.Column="1" Text="{Binding Name}" VerticalOptions="Center" TextColor="Black">
                                             <Label.GestureRecognizers>
                                                 <TapGestureRecognizer Command="{Binding Source={x:Reference Page}, Path=BindingContext.EditRoutineCommand}" CommandParameter="{Binding .}" />
                                             </Label.GestureRecognizers>

--- a/Planner/Views/RoutineListPage.xaml
+++ b/Planner/Views/RoutineListPage.xaml
@@ -19,7 +19,7 @@
                             <Frame Padding="10" Margin="0,5" HasShadow="True" BackgroundColor="White" CornerRadius="8">
                                 <Grid ColumnDefinitions="Auto,*" VerticalOptions="Center">
                                     <CheckBox IsChecked="{Binding IsCompleted}" CheckedChanged="OnRoutineChecked" VerticalOptions="Center" />
-                                    <Label Grid.Column="1" Text="{Binding Name}" VerticalOptions="Center">
+                                    <Label Grid.Column="1" Text="{Binding Name}" VerticalOptions="Center" TextColor="Black">
                                         <Label.GestureRecognizers>
                                             <TapGestureRecognizer Command="{Binding Source={x:Reference Page}, Path=BindingContext.EditRoutineCommand}" CommandParameter="{Binding .}" />
                                         </Label.GestureRecognizers>

--- a/Planner/Views/RoutineTemplatePage.xaml
+++ b/Planner/Views/RoutineTemplatePage.xaml
@@ -25,8 +25,8 @@
                             </SwipeView.RightItems>
                             <Frame Padding="10" Margin="0,5" HasShadow="True" BackgroundColor="White" CornerRadius="8">
                                 <StackLayout>
-                                    <Label Text="{Binding Name}" FontAttributes="Bold" />
-                                    <Label Text="{Binding RepeatOnDays, Converter={StaticResource RepeatDaysConverter}}" FontAttributes="Italic" FontSize="12" />
+                                    <Label Text="{Binding Name}" FontAttributes="Bold" TextColor="Black" />
+                                    <Label Text="{Binding RepeatOnDays, Converter={StaticResource RepeatDaysConverter}}" FontAttributes="Italic" FontSize="12" TextColor="Black" />
                                 </StackLayout>
                             </Frame>
                         </SwipeView>


### PR DESCRIPTION
## Summary
- support routine reminders with new fields
- schedule local notifications via ReminderService
- initialize notifications in the app
- add Android notification permission
- register ReminderService in DI container
- show routine text in black so it's visible

## Testing
- `dotnet workload restore Planner/Planner.csproj`
- `dotnet build Planner.sln -c Release` *(fails: Microsoft.iOS SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856b5b5c6508331a33cdc5a5950b534